### PR TITLE
Fix compilation and version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,4 @@ authors = ["Mikkel Schubert <MikkelSch@gmail.com>"]
 [dependencies]
 clap = "2.20.5"
 libc = "0.2.11"
-unicode-width = "0.1.3"
+unicode-width = "0.1.4"

--- a/src/args.rs
+++ b/src/args.rs
@@ -16,8 +16,8 @@ pub struct Args {
 
 pub fn parse_args() -> Args {
     let matches =
-        App::new("sstar")
-            .version("0.0.1")
+        App::new("retable")
+            .version("0.0.2")
             .author("Mikkel Schubert")
             .arg(Arg::with_name("--column-token")
                      .help("Split columns using this character [default: \\t]")


### PR DESCRIPTION
- compilation on mac sierra (cargo v0.20.0) required a newer unicode version.
- `retable -V` now returns `retable`